### PR TITLE
Add *.apple.com to referrer whitelist for icloud.com

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -23,6 +23,11 @@
                 "https://cdn.embedly.com/*",
                 "https://imgur.com/*"
             ]
+        },
+        {
+            "https://www.icloud.com/*": [
+                "https://*.apple.com/*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2622

test plan:
1. copy `data/ReferrerWhitelist.json` into `~/Library/Application\ Support/BraveSoftware/Brave-Browser-Development/afalakplffnnnlkncjhbmahjfjhmlkal/1.0.11/1/` or equivalent for your OS/channel
2. start brave and go to icloud.com
3. the login page should load