### PR TITLE
Allow referrer on https://www.sfoutsidelands.com/lineup/#/lineup_grou…

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -23,6 +23,11 @@
                 "https://cdn.embedly.com/*",
                 "https://imgur.com/*"
             ]
-        }
+        },
+	{
+	    "https://www.sfoutsidelands.com/*": [
+		"https://*.dostff.co/*"
+	    ]
+	}
     ]
 }

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -24,10 +24,10 @@
                 "https://imgur.com/*"
             ]
         },
-	{
-	    "https://www.sfoutsidelands.com/*": [
-		"https://*.dostff.co/*"
-	    ]
-	}
+        {
+            "https://www.sfoutsidelands.com/*": [
+                "https://*.dostff.co/*"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
As reported, https://www.sfoutsidelands.com/lineup/ was broken due to referrer stopping dostff from loading. Made specific for the time being. If this script is popular enough, might be worth making generic.