### PR TITLE
Allow gigya (social) generate login element

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -6,7 +6,8 @@
                 "https://api.geetest.com/*",
                 "https://cloud.typography.com/*",
                 "https://*.vimeocdn.com/*",
-                "https://player.vimeo.com/*"
+                "https://player.vimeo.com/*",
+                "https://*.gigya.com/*"
             ]
         },
         {


### PR DESCRIPTION
Reported here;

`https://community.brave.com/t/unable-to-sign-on-to-nj-com-web-site/75761`

Users can't login without allowing cookies, this seems to work better instead.  Has been tested in Brave release, and login window will be shown if we allow referrer on gigya.com.

`nj.com` is made up of many region sites. (which is why I made it generic). Possibly fixing other sites using gigya for logins.

`cleveland.com,gulflive.com,lehighvalleylive.com,masslive.com,mlive.com,newyorkupstate.com,nj.com,nola.com,oregonlive.com,pennlive.com,silive.com,syracuse.com`
