### PR TITLE
Fix referrer issues on https://www.nin.com/

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -40,6 +40,11 @@
             "https://codepen.io/*": [
                 "https://cdpn.io/*"
             ]
-        }
+        },
+        {
+            "https://www.nin.com/*": [
+		"https://*.netdna-ssl.com/*"
+            ]
+	}
     ]
 }


### PR DESCRIPTION
In this case referrer fix caused by netdna on nin.com causing the site to break upon loading. Was reported in Slack by @murphyd . Was tested, and confirmed this fixed it. 

@pilgrim-brave  :)