### PR TITLE
Fix css-tricks.com referrer issues with cdpn.io

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -38,13 +38,18 @@
             ]
         },
         {
+            "https://css-tricks.com/*": [
+                "https://cdpn.io/*"
+            ]
+        },
+        {
             "https://codepen.io/*": [
                 "https://cdpn.io/*"
             ]
         },
         {
             "https://www.nin.com/*": [
-		"https://*.netdna-ssl.com/*"
+                "https://*.netdna-ssl.com/*"
             ]
 	}
     ]


### PR DESCRIPTION
Codepen used on css-tricks.com;

`https://css-tricks.com/using-requestanimationframe-with-react-hooks/`

Allows the embedded cdpn.io to work.