### PR TITLE
Fix #16: Update referrer whitelist to allow bing logins

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -11,6 +11,18 @@
             ]
         },
         {
+            "https://www.bing.com/*": [
+                "https://www.bing.com/*",
+                "https://login.live.com/*"
+            ]
+        },
+        {
+            "https://login.live.com/*": [
+                "https://www.bing.com/*",
+                "https://login.live.com/*"
+            ]
+        },
+        {
             "https://www.facebook.com/": [
                 "https://*.fbcdn.net/*"
             ]


### PR DESCRIPTION
Fix https://github.com/brave/referrer-whitelist/issues/16