### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/7505

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -7,7 +7,8 @@
                 "https://cloud.typography.com/*",
                 "https://*.vimeocdn.com/*",
                 "https://player.vimeo.com/*",
-                "https://*.gigya.com/*"
+                "https://*.gigya.com/*",
+                "https://*.spreedly.com/*"
             ]
         },
         {


### PR DESCRIPTION
Allowing referrer for spreedly.com (payment provider) will fix this, and allow the end user to enter their credit card details to book a movie on `https://riotheatretickets.ca/checkout`