### PR TITLE
Fix google maps on anibis.ch

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -74,6 +74,11 @@
             "https://*.atlassian.net/*": [
                 "https://atlassian.net/*"
             ]
+        },
+        {
+            "https://*.anibis.ch/*": [
+                "https://*.google.com/*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Requires a Swiss VPN;

Visiting this site currently will show an error when generating the google map.
`https://www.anibis.ch/fr/d-v%c3%aatements-~-accessoires-chaussures-femmes--842/bottes-en-cuir-style-daim-noires-commes-neuves-taille-36--32168980.aspx?view=2&pr=4` or any links from `https://www.anibis.ch/fr/default.aspx`

`Google Maps Platform rejected your request. This IP, site or mobile application is not authorized to use this API key. Request received from IP address xxx.xxx.xxx.xxx, with referer: https://www.google.com/`

This will prevent the error from showing. Did try to make this generic to *.google/maps/* but this didn't fix the issue on anibis.ch

Was reported here: https://community.brave.com/t/google-maps-not-displayed-in-brave-only/101654/2