### PR TITLE
Fix Referrer issues on https://developers.google.com/speed/pagespeed/insights/

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -34,6 +34,11 @@
             ]
         },
         {
+            "https://developers.google.com/*": [
+                "https://*.googleapis.com/*"
+            ]
+        },
+        {
             "https://www.reddit.com/*": [
                 "https://www.redditmedia.com/*",
                 "https://cdn.embedly.com/*",


### PR DESCRIPTION
Enabling "All Cookies" will still generate Referrer issues. Test site: `https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Ftwitter.com%2Fhome`

`Requests from referer https://www.googleapis.com/ are blocked.`

Could make it generic for *.google.com (combing the accounts.google.com), but decided to make it specific.

Any questions @pilgrim-brave  :)

Was reported here: https://community.brave.com/t/googles-pagespeed-insights-does-not-work/101766/5