### PR TITLE
Fix LocationIQ maps referrer issues

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -9,6 +9,7 @@
                 "https://player.vimeo.com/*",
                 "https://*.gigya.com/*",
                 "https://*.spreedly.com/*"
+                "https://*.locationiq.org/*"
             ]
         },
         {

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -8,7 +8,7 @@
                 "https://*.vimeocdn.com/*",
                 "https://player.vimeo.com/*",
                 "https://*.gigya.com/*",
-                "https://*.spreedly.com/*"
+                "https://*.spreedly.com/*",
                 "https://*.locationiq.org/*"
             ]
         },


### PR DESCRIPTION
Signing up on `https://www.life360.com/circles/?#/map`

Then zooming via the map, will cause the page to blank out when zoomed in. Possibly any other site using `locationiq.org` for mapping would also be affected here. This referrer fix will allow people to browse this site correctly.

Was reported here: https://community.brave.com/t/braze-not-displaying-loading-caching-life360-com-map-tiles/102471/2