### PR TITLE
Fix referrer issues with payment provider ccavenue.com

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -9,7 +9,8 @@
                 "https://player.vimeo.com/*",
                 "https://*.gigya.com/*",
                 "https://*.spreedly.com/*",
-                "https://*.locationiq.org/*"
+                "https://*.locationiq.org/*",
+                "https://*.ccavenue.com/*"
             ]
         },
         {


### PR DESCRIPTION
This will allow any site to embed ccavenue.com correctly.

Testing by donating trees on `https://www.ishaoutreach.org/`  When the payment option comes up, it'll error. Allowing referrer for `ccavenue.com` will fix this.