### PR TITLE
Fix referrer issue on https://services.paysf.co/

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -26,6 +26,11 @@
             ]
         },
         {
+            "https://services.paysf.co/*": [
+                "https://*.prod.cityba.se/*"
+            ]
+        },
+        {
             "https://www.facebook.com/": [
                 "https://*.fbcdn.net/*"
             ]


### PR DESCRIPTION
Fixes `https://services.paysf.co/service/give2sf`  Which show a blank page, allowing prod.cityba.se will fix this site.

Loading this script:
`https://graphql-omnischema.prod.cityba.se/graphql`