### PR TITLE
Fixes brave/brave-browser#9279

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -31,6 +31,11 @@
             ]
         },
         {
+            "https://www.worldometers.info/*": [
+                "https://*.realtimestatistics.net/*"
+            ]
+        },
+        {
             "https://www.facebook.com/": [
                 "https://*.fbcdn.net/*"
             ]


### PR DESCRIPTION
Fixes referrer issues on  `https://www.worldometers.info/`  Allows the counter to now work.
