### PR TITLE
always send referrer to googleapis.com

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -10,7 +10,8 @@
                 "https://*.gigya.com/*",
                 "https://*.spreedly.com/*",
                 "https://*.locationiq.org/*",
-                "https://*.ccavenue.com/*"
+                "https://*.ccavenue.com/*",
+                "https://*.googleapis.com/*"
             ]
         },
         {
@@ -38,16 +39,6 @@
         {
             "https://www.facebook.com/": [
                 "https://*.fbcdn.net/*"
-            ]
-        },
-        {
-            "https://accounts.google.com/": [
-                "https://content.googleapis.com/*"
-            ]
-        },
-        {
-            "https://developers.google.com/*": [
-                "https://*.googleapis.com/*"
             ]
         },
         {


### PR DESCRIPTION
Always send referrer to googleapis.com to unbreak a number of issues, including https://github.com/brave/brave-browser/issues/1122

This is a temporary step until https://github.com/brave/brave-browser/issues/8696 comes through, which would fix the issue in general and remove the need for most (all?) of these exceptions.