### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/9396

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -11,7 +11,8 @@
                 "https://*.spreedly.com/*",
                 "https://*.locationiq.org/*",
                 "https://*.ccavenue.com/*",
-                "https://*.googleapis.com/*"
+                "https://*.googleapis.com/*",
+                "https://*.postcodeanywhere.co.uk/*"
             ]
         },
         {


### PR DESCRIPTION
This fixes a referrer issue when sites are using `postcodeanywhere.co.uk` to get address/postcode details when purchasing products. 

https://github.com/brave/brave-browser/issues/9396