### PR TITLE
Fix referrer issue on source.chromium.org

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -88,6 +88,11 @@
             "https://*.anibis.ch/*": [
                 "https://*.google.com/*"
             ]
+        },
+        {
+            "https://source.chromium.org/*": [
+               "https://*.clients6.google.com/*"
+            ]
         }
     ]
 }

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -91,7 +91,7 @@
         },
         {
             "https://source.chromium.org/*": [
-               "https://*.clients6.google.com/*"
+               "https://*.google.com/*"
             ]
         }
     ]


### PR DESCRIPTION
Fixes permission denied on `https://source.chromium.org/chromium/chromium/src/+/master:components/prefs/writeable_pref_store.cc;l=7?q=WriteablePrefStore::ReportSubValuesChanged&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2Fchromium%2Fsrc%2Fcomponents%2Fprefs%2Fwriteable_pref_store.cc`

