### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/2840

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -11,6 +11,7 @@
                 "https://*.spreedly.com/*",
                 "https://*.locationiq.org/*",
                 "https://*.ccavenue.com/*",
+                "https://apis.google.com/*",
                 "https://*.googleapis.com/*",
                 "https://*.postcodeanywhere.co.uk/*"
             ]


### PR DESCRIPTION
Managed to debug this properly, This will fix  https://gallery.io/#recent (a google login required).

Since we're already allowing, `*.googleapis.com/*",` this just an extenstion of same/similar google apis. will help blank issues on this page.

If it looks good @pilgrim-brave 