### PR TITLE
Fix Creditcard issues on https://www.chipotle.com/order/checkout

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -13,7 +13,8 @@
                 "https://*.ccavenue.com/*",
                 "https://apis.google.com/*",
                 "https://*.googleapis.com/*",
-                "https://*.postcodeanywhere.co.uk/*"
+                "https://*.postcodeanywhere.co.uk/*",
+                "https://*.paymentjs.firstdata.com/*"
             ]
         },
         {


### PR DESCRIPTION
Reported issues when making payment via `https://www.chipotle.com/`

`firstdata.com` is a payment provider, its probably a good idea to let this through. Full Domain being used on Chipotle `https://docs.paymentjs.firstdata.com/` 

If it looks okay @pilgrim-brave 