### PR TITLE
Fix Shopping cart on https://overture3d.com/

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -14,7 +14,8 @@
                 "https://apis.google.com/*",
                 "https://*.googleapis.com/*",
                 "https://*.postcodeanywhere.co.uk/*",
-                "https://*.paymentjs.firstdata.com/*"
+                "https://*.paymentjs.firstdata.com/*",
+                "https://pay.google.com/*"
             ]
         },
         {


### PR DESCRIPTION
Parts of the shopping cart fails to load due in `https://overture3d.com/products/overture-3d-printer-build-surface` due to referrer issues on `https://pay.google.com/*`  

Was reported by @antonok-edm   If this looks okay @pilgrim-brave  thanks :)