### PR TITLE
Fix map issues on https://www.obdach.wien/p/obdachlos-tageszentren-josi

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -93,6 +93,11 @@
             ]
         },
         {
+            "https://www.obdach.wien/*": [
+                "https://*.google.com/*"
+            ]
+        },
+        {
             "https://source.chromium.org/*": [
                "https://*.google.com/*"
             ]


### PR DESCRIPTION
Due to google referrer issues, maps on `https://www.obdach.wien/p/obdachlos-tageszentren-josi` will fail to load. Force refresh of page will be needed also.

Was reported here: https://community.brave.com/t/google-maps-not-working/131134

If it looks okay @pilgrim-brave 