### PR TITLE
Fixes menus on https://store.playstation.com/

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -93,6 +93,12 @@
             ]
         },
         {
+            "https://*.playstation.com/*":[
+                "https://*.sony.com/*",
+                "https://*.sonyentertainmentnetwork.com/*"
+            ]
+        },
+        {
             "https://source.chromium.org/*": [
                "https://*.google.com/*"
             ]

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -93,7 +93,7 @@
             ]
         },
         {
-            "https://*.playstation.com/*":[
+            "https://*.playstation.com/*": [
                 "https://*.sony.com/*",
                 "https://*.sonyentertainmentnetwork.com/*"
             ]


### PR DESCRIPTION
This will help fix issues on  https://github.com/brave/brave-browser/issues/9987

Playstation menus fail to load correctly, referrer issues between various sony domains.

If this looks good @pilgrim-brave 