### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/8913

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -6,6 +6,7 @@
                 "https://api.geetest.com/*",
                 "https://cloud.typography.com/*",
                 "https://*.vimeocdn.com/*",
+                "https://*.wix.com/*",
                 "https://player.vimeo.com/*",
                 "https://*.gigya.com/*",
                 "https://*.spreedly.com/*",


### PR DESCRIPTION
Wix is quite popular is should be generic avoid other wix referrer issues

Fixing login details on https://github.com/brave/brave-browser/issues/8913