### PR TITLE
Fixes https://www.caymanenterprisecity.com/tech-talks-bitcoin

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -17,7 +17,8 @@
                 "https://*.postcodeanywhere.co.uk/*",
                 "https://*.paymentjs.firstdata.com/*",
                 "https://pay.google.com/*",
-                "https://*.mapbox.com/*"
+                "https://*.mapbox.com/*",
+                "https://*.hsforms.com/*"
             ]
         },
         {


### PR DESCRIPTION
Allowing refer on hsforms (which could possible  affect other submission hsforms).

Visit `https://www.caymanenterprisecity.com/tech-talks-bitcoin` submission fails.

If this looks good @pilgrim-brave 