### PR TITLE
added mojeID

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -19,6 +19,7 @@
                 "https://pay.google.com/*",
                 "https://*.mapbox.com/*",
                 "https://*.hsforms.com/*"
+                "https://*.mojeid.cz/*"
             ]
         },
         {

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -18,7 +18,7 @@
                 "https://*.paymentjs.firstdata.com/*",
                 "https://pay.google.com/*",
                 "https://*.mapbox.com/*",
-                "https://*.hsforms.com/*"
+                "https://*.hsforms.com/*",
                 "https://*.mojeid.cz/*"
             ]
         },


### PR DESCRIPTION
I have added mojeID, which is a project by CZ.NIC, the association which main activity is the administration of domain names .cz.
It is impossible to log in through Brave. It gives the following message:

> UNFORTUNATELY YOU CAN'T CONTINUE
> The CSRF protection checks didn't pass.
> Please start again from the home page.
> 
> You are seeing this message because this HTTPS site requires a 'Referer header' to be sent by your web browser, but none was sent. This header is required for security reasons, to ensure that your browser is not being hijacked by third parties.
> 
> If you have configured your browser to disable 'Referer' headers, please re-enable them, at least for this site, or for HTTPS connections, or for 'same-origin' requests.

I hope this will fix the issue.