### PR TITLE
Allow google login popup on nytimes, linkedin

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -18,7 +18,8 @@
                 "https://*.paymentjs.firstdata.com/*",
                 "https://pay.google.com/*",
                 "https://*.mapbox.com/*",
-                "https://*.hsforms.com/*"
+                "https://*.hsforms.com/*",
+                "https://accounts.google.com/*"
             ]
         },
         {


### PR DESCRIPTION
This will allow the google logins popup on linkedin and nytimes (and probably other sites).

![google-login](https://user-images.githubusercontent.com/1659004/89479155-316e8d00-d7e6-11ea-80aa-f7c9a8498c6b.png)

@pilgrim-brave 