### PR TITLE
Allow Google Maps Embed on Mudafy websites

### DIFF
--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -122,6 +122,16 @@
                 "https://*.google.com/*"
             ]
         },
+	{
+            "https://mudafy.com.ar/*": [
+                "https://*.google.com/*"
+            ]
+        },
+	{
+            "https://mudafy.com.mx/*": [
+                "https://*.google.com/*"
+            ]
+        },
         {
             "https://source.chromium.org/*": [
                "https://*.google.com/*"

--- a/data/ReferrerWhitelist.json
+++ b/data/ReferrerWhitelist.json
@@ -95,7 +95,7 @@
             "https://www.nin.com/*": [
                 "https://*.netdna-ssl.com/*"
             ]
-	},
+        },
         {
             "https://id.atlassian.com/*": [
                 "https://atlassian.net/*"
@@ -122,24 +122,24 @@
                 "https://*.google.com/*"
             ]
         },
-	{
+        {
             "https://mudafy.com.ar/*": [
                 "https://*.google.com/*"
             ]
         },
-	{
+        {
             "https://mudafy.com.mx/*": [
                 "https://*.google.com/*"
             ]
         },
         {
             "https://source.chromium.org/*": [
-               "https://*.google.com/*"
+                "https://*.google.com/*"
             ]
         },
         {
-           "https://twist.moe/*": [
-               "https://*.bunny.sh/*"
+            "https://twist.moe/*": [
+                "https://*.bunny.sh/*"
             ]
         }
     ]


### PR DESCRIPTION
This will allow loading Google Maps on our websites (https://mudafy.com.ar and https://mudafy.com.mx).

We opened this issue based on this comment: https://community.brave.com/t/google-maps-not-working/131134/2